### PR TITLE
Detect default installations of Adoptium on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ It currently detects JREs managed by :
 - [JBang](https://www.jbang.dev/)
 
 It also detects JREs installed on platform-specific locations:
-- `/usr/lib/jvm` on Linux 
+- `/usr/lib/jvm` on Linux
+- `%PROGRAMFILES%\Eclipse Adoptium` on Windows
 
 Managed JREs will be automatically discovered on Eclipse startup, or, while running, when added by their respective Java managers.
 

--- a/io.sidespin.jre.discovery.core/plugin.xml
+++ b/io.sidespin.jre.discovery.core/plugin.xml
@@ -1,45 +1,55 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin>
-<extension-point id="managedVMDetectorDefinition"
-					name="Managed VM Detector Definition"
-					schema="schemas/managedVMDetectorDefinition.exsd" />
-<extension
-         point="io.sidespin.jre.discovery.core.managedVMDetectorDefinition">
-      <simpleDetector
-            id="sdkman"
-            label="SDKMan"
-            directory="~/.sdkman/candidates/java"
-            isWatchingByDefault="true"
-       />
-       <simpleDetector
-       		id="jbang"
-       		label="JBang"
-       		directory="~/.jbang/cache/jdks"
-       		isWatchingByDefault="true"
-       />
-       <simpleDetector
-       		id="jabba"
-       		label="Jabba"
-       		directory="~/.jabba/jdk"
-       		isWatchingByDefault="true"
-       />
-       <simpleDetector
-       		id="asdf"
-       		label="asdf"
-       		directory="~/.asdf/installs/java"
-       		isWatchingByDefault="true"
-       />
-       <simpleDetector
-       		id="linux"
-       		label="System"
-       		directory="/usr/lib/jvm"
-       		isWatchingByDefault="true">
-       		<enablement>
-       			<systemTest property="osgi.os" value="linux"/>
-            </enablement>
-       </simpleDetector>
-   </extension>
-   <extension point="org.eclipse.core.runtime.preferences">
-      <initializer class="io.sidespin.eclipse.jre.discovery.core.internal.preferences.JREDiscoveryPreferenceInitializer"/>
-   </extension>
+	<extension-point id="managedVMDetectorDefinition"
+		name="Managed VM Detector Definition"
+		schema="schemas/managedVMDetectorDefinition.exsd" />
+	<extension
+		point="io.sidespin.jre.discovery.core.managedVMDetectorDefinition">
+		<simpleDetector
+			id="sdkman"
+			label="SDKMan"
+			directory="~/.sdkman/candidates/java"
+			isWatchingByDefault="true"
+		/>
+		<simpleDetector
+			id="jbang"
+			label="JBang"
+			directory="~/.jbang/cache/jdks"
+			isWatchingByDefault="true"
+		/>
+		<simpleDetector
+			id="jabba"
+			label="Jabba"
+			directory="~/.jabba/jdk"
+			isWatchingByDefault="true"
+		/>
+		<simpleDetector
+			id="asdf"
+			label="asdf"
+			directory="~/.asdf/installs/java"
+			isWatchingByDefault="true"
+		/>
+		<simpleDetector
+			id="linux"
+			label="System"
+			directory="/usr/lib/jvm"
+			isWatchingByDefault="true">
+			<enablement>
+				<systemTest property="osgi.os" value="linux" />
+			</enablement>
+		</simpleDetector>
+		<simpleDetector
+			id="adoptium"
+			label="Adoptium"
+			directory="${env_var:PROGRAMFILES}/Eclipse Adoptium"
+			isWatchingByDefault="true">
+			<enablement>
+				<systemTest property="osgi.os" value="win32" />
+			</enablement>
+		</simpleDetector>
+	</extension>
+	<extension point="org.eclipse.core.runtime.preferences">
+		<initializer
+			class="io.sidespin.eclipse.jre.discovery.core.internal.preferences.JREDiscoveryPreferenceInitializer" />
+	</extension>
 </plugin>

--- a/io.sidespin.jre.discovery.ui/src/main/java/io/sidespin/eclipse/jre/discovery/ui/internal/preferences/JREDiscoveryPreferencePage.java
+++ b/io.sidespin.jre.discovery.ui/src/main/java/io/sidespin/eclipse/jre/discovery/ui/internal/preferences/JREDiscoveryPreferencePage.java
@@ -33,7 +33,7 @@ public class JREDiscoveryPreferencePage extends FieldEditorPreferencePage implem
 
   @Override
   public void init(IWorkbench workbench) {
-	  setDescription("Automatically detect JREs managed by SDKMan, JBang, asdf or Jabba. Also detects installations in /usr/lib/jvm on Linux.");
+	  setDescription("Automatically detect JREs managed by SDKMan, JBang, asdf or Jabba. Also detects installations in /usr/lib/jvm on Linux and Eclipse Adoptium installations on Windows.");
   }
 
   @Override
@@ -46,7 +46,7 @@ public class JREDiscoveryPreferencePage extends FieldEditorPreferencePage implem
     		JREDiscoveryPreferences.WATCH_JRE_DIRECTORIES_KEY, "Watch managed JRE directories",
         getFieldEditorParent());
     addField(watchDirectories);
-    
+
     BooleanFieldEditor displayNotifications = new BooleanFieldEditor(
     		JREDiscoveryPreferences.NOTIFICATIONS_ENABLED_KEY, "Enable notifications when new JREs are detected",
         getFieldEditorParent());


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/406876/224367932-31590eae-0392-41ed-99a8-8a885ee08397.png)

You may want to come up with a better and generic placeholder for environment variables eventually, before merging this. However, be aware that the intuitive "%PROGRAMFILES%" (as used in Windows itself) totally doesn't work, because %PROGRAMFILES is considered a localization entry by PDE. :)

This detector is not specific to a manager. It works with native Adoptium installations, Chocolatey Adoptium installations etc.