### PR TITLE
Detect /usr/lib/jvm JDKs on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ It currently detects JREs managed by :
 - [Jabba](https://github.com/shyiko/jabba) 
 - [JBang](https://www.jbang.dev/)
 
+It also detects JREs installed on platform-specific locations:
+- `/usr/lib/jvm` on Linux 
+
 Managed JREs will be automatically discovered on Eclipse startup, or, while running, when added by their respective Java managers.
 
 ![Detected JREs](images/jre-discovery.png)

--- a/io.sidespin.jre.discovery.core/META-INF/MANIFEST.MF
+++ b/io.sidespin.jre.discovery.core/META-INF/MANIFEST.MF
@@ -14,3 +14,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: io.sidespin.jre.discovery.core
 Export-Package: io.sidespin.eclipse.jre.discovery.core.internal,
  io.sidespin.eclipse.jre.discovery.core.internal.preferences
+Import-Package: org.eclipse.core.expressions, org.eclipse.core.variables

--- a/io.sidespin.jre.discovery.core/plugin.xml
+++ b/io.sidespin.jre.discovery.core/plugin.xml
@@ -29,6 +29,15 @@
        		directory="~/.asdf/installs/java"
        		isWatchingByDefault="true"
        />
+       <simpleDetector
+       		id="linux"
+       		label="System"
+       		directory="/usr/lib/jvm"
+       		isWatchingByDefault="true">
+       		<enablement>
+       			<systemTest property="osgi.os" value="linux"/>
+            </enablement>
+       </simpleDetector>
    </extension>
    <extension point="org.eclipse.core.runtime.preferences">
       <initializer class="io.sidespin.eclipse.jre.discovery.core.internal.preferences.JREDiscoveryPreferenceInitializer"/>

--- a/io.sidespin.jre.discovery.ui/src/main/java/io/sidespin/eclipse/jre/discovery/ui/internal/preferences/JREDiscoveryPreferencePage.java
+++ b/io.sidespin.jre.discovery.ui/src/main/java/io/sidespin/eclipse/jre/discovery/ui/internal/preferences/JREDiscoveryPreferencePage.java
@@ -33,7 +33,7 @@ public class JREDiscoveryPreferencePage extends FieldEditorPreferencePage implem
 
   @Override
   public void init(IWorkbench workbench) {
-	  setDescription("Automatically detect JREs managed by SDKMan, JBang, asdf or Jabba.");
+	  setDescription("Automatically detect JREs managed by SDKMan, JBang, asdf or Jabba. Also detects installations in /usr/lib/jvm on Linux.");
   }
 
   @Override


### PR DESCRIPTION
Uses the core expression framework as discussed in #9, to enable the detector on Linux only.
IStringVariableManager also processes the directory values, so it can be reused in #9 directly. 

Signed-off-by: Fred Bricon <fbricon@gmail.com>
